### PR TITLE
[Fix]: Changes default Java source version to 17

### DIFF
--- a/framework/src/play/classloading/ApplicationCompiler.java
+++ b/framework/src/play/classloading/ApplicationCompiler.java
@@ -36,7 +36,7 @@ public class ApplicationCompiler {
     Map<String, Boolean> packagesCache = new HashMap<>();
     ApplicationClasses applicationClasses;
     Map<String, String> settings;
-    private static final String JAVA_SOURCE_DEFAULT_VERSION = "1.8";
+    private static final String JAVA_SOURCE_DEFAULT_VERSION = "17";
     static final Map<String, String> compatibleJavaVersions = new HashMap<>();
 
     static {


### PR DESCRIPTION
There was an error when trying to use the new `record` feature on Java 17:
![image](https://user-images.githubusercontent.com/85994582/172861263-5471d4a0-cc38-4873-9da4-84db5edb088f.png)

This PR changes the default Java version on JDT compiler to 17.